### PR TITLE
Fix Docker build by specifying UV version in nixpacks.toml

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -2,6 +2,10 @@
 
 providers = ["deno", "python"]
 
+[variables]
+# Specify the UV version to install
+NIXPACKS_UV_VERSION = "0.8.17"
+
 [phases.setup]
 nixPkgs = [
   "...",


### PR DESCRIPTION
The build was failing with "ERROR: Invalid requirement: 'uv=='" because
$NIXPACKS_UV_VERSION was undefined. This adds the variable to nixpacks.toml
to ensure uv 0.8.17 is installed during the Docker build.