### PR TITLE
Fix redundant JavaScript error message wrapping

### DIFF
--- a/src/emilybot/commands/run.py
+++ b/src/emilybot/commands/run.py
@@ -66,7 +66,7 @@ async def cmd_cmd(ctx: EmilyContext, alias: str, *, args: list[str]) -> None:
         if success:
             await ctx.send(format_show_content(output, value))
         else:
-            await ctx.send(f"❌ Error executing JavaScript: {output}")
+            await ctx.send(output)  # Error message is already formatted
 
     except ValidationError as e:
         await ctx.send(format_validation_error(str(e)))

--- a/src/emilybot/commands/show.py
+++ b/src/emilybot/commands/show.py
@@ -132,7 +132,7 @@ async def cmd_random(ctx: EmilyContext, alias: str) -> None:
             ctx, code=f"$.cmd('{json.dumps(entry.name)}')"
         )
         if not success:
-            await ctx.send(f"❌ Error executing JavaScript: {output}")
+            await ctx.send(output)  # Error message is already formatted
             return
 
         # Split content into lines and filter out blank lines

--- a/src/emilybot/execute/javascript_executor.py
+++ b/src/emilybot/execute/javascript_executor.py
@@ -240,19 +240,19 @@ class JavaScriptExecutor:
                 elif error_type == "syntax":
                     return (
                         False,
-                        f"❌ JavaScript syntax error: {stderr_text}",
+                        f"❌ {stderr_text}",
                         None,
                     )
                 elif error_type == "runtime":
                     return (
                         False,
-                        f"⚠️ JavaScript runtime error: {stderr_text}",
+                        f"❌ {stderr_text}",
                         None,
                     )
                 else:
                     return (
                         False,
-                        f"❌ JavaScript execution failed: {error_message}",
+                        f"❌ {error_message}",
                         None,
                     )
 


### PR DESCRIPTION
Addressed Silvy's complaint about redundant error messages when JS errors occur.

Previously, errors were wrapped three times:
1. TypeScript executor: "Command 'X' has invalid JavaScript..."
2. Python executor: "⚠️ JavaScript runtime error: [error from 1]"
3. Commands: "❌ Error executing JavaScript: [error from 2]"

This resulted in messages like:
"❌ Error executing JavaScript: ⚠️ JavaScript runtime error: Command 'taunt' has invalid JavaScript and cannot be executed: [actual error]"

Changes:
- Simplified error messages in javascript_executor.py to just "❌ [error]"
  instead of adding redundant prefixes like "JavaScript runtime error:"
- Removed the extra "❌ Error executing JavaScript:" wrapper from
  cmd_cmd and cmd_random, making them consistent with cmd_run
- Error messages now display cleanly with just one emoji prefix

Now errors appear as:
"❌ Command 'taunt' has invalid JavaScript and cannot be executed: [actual error]"

This provides a cleaner user experience while still clearly indicating
that an error occurred.